### PR TITLE
Karts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,644 +28,644 @@
 ## Boomhill
 
 ### Chapter 1
-\#  | Track | Mode
---- | ----- | ----
-1-1 | Canal (Village) | Tr
-1-2 | Specter Pass (Tomb) | Tr
-1-3 | Large Hot Rod Collider (Brodi) | L
-1-4 | Lumberjack Lane (Wyldwood) | I
-1-5 | Up 'N' Down (Village) | B
-1-6 | Formula 51 (Northeu) | S
+\#  | Track | Mode | Kart
+--- | ----- | ---- | ----
+1-1 | Canal (Village) | Tr | Burst
+1-2 | Specter Pass (Tomb) | Tr | Burst
+1-3 | Large Hot Rod Collider (Brodi) | L | Burst
+1-4 | Lumberjack Lane (Wyldwood) | I | Turbo Tortoise
+1-5 | Up 'N' Down (Village) | B | Strike
+1-6 | Formula 51 (Northeu) | S | Strike
 
 ### Chapter 2
-\#  | Track | Mode
---- | ----- | ----
-2-1 | Bridge Run (Beach) | Tr
-2-2 | Shark's Tomb (Ice) | I
-2-3 | Canal (Village) | R
-2-4 | Paris Grand Prix (World) | L
-2-5 | Singapore Circuit (WKC) | Tc
-2-6 | Up 'N' Down (Village) | F
+\#  | Track | Mode | Kart
+--- | ----- | ---- | ----
+2-1 | Bridge Run (Beach) | Tr | Practice Kart
+2-2 | Shark's Tomb (Ice) | I | Banana Split
+2-3 | Canal (Village) | R | Marathon
+2-4 | Paris Grand Prix (World) | L | Solid
+2-5 | Singapore Circuit (WKC) | Tc | Storm
+2-6 | Up 'N' Down (Village) | F | Lodi Albert
 
 ### Chapter 3
-\#  | Track | Mode
---- | ----- | ----
-3-1 | Mile High Motorway (Northeu) | S
-3-2 | Pharoah's Pass (Desert) | Tc
-3-3 | Shanghai Noon (China) | S
-3-4 | Downtown Dubai (World) | C
-3-5 | Mediea's Hideaway (Block) | I
-3-6 | Singapore Circuit (WKC) | Em
+\#  | Track | Mode | Kart
+--- | ----- | ---- | ----
+3-1 | Mile High Motorway (Northeu) | S | Strike
+3-2 | Pharoah's Pass (Desert) | Tc | Solid
+3-3 | Shanghai Noon (China) | S | Lodi Albert
+3-4 | Downtown Dubai (World) | C | Panda Buggy
+3-5 | Mediea's Hideaway (Block) | I | Rudolf
+3-6 | Singapore Circuit (WKC) | Em | Solar
 
 ### Chapter 4
-\#  | Track | Mode
---- | ----- | ----
-4-1 | Paris Grand Prix (World) | S
-4-2 | Bridge Run (Beach) | Tr
-4-3 | Huangshan Highway (China) | F
-4-4 | The Great Wall (Village) | Em
-4-5 | Up 'N' Down (Village) | Tc
-4-6 | Dragon's Canal (China) | S
+\#  | Track | Mode | Kart
+--- | ----- | ---- | ----
+4-1 | Paris Grand Prix (World) | S | Solid
+4-2 | Bridge Run (Beach) | Tr | Marathon
+4-3 | Huangshan Highway (China) | F | Panda Buggy
+4-4 | The Great Wall (Village) | Em | Turbo Tortoise
+4-5 | Up 'N' Down (Village) | Tc | Golden Roadhog
+4-6 | Dragon's Canal (China) | S | Unicorn Chariot
 
 ### Chapter 5
-\#  | Track | Mode
---- | ----- | ----
-5-1 | Beguy Market (Desert) | I
-5-2 | Handy Harbor (Village) | F
-5-3 | Downtown Dubai (World) | Em
-5-4 | Specter Pass (Tomb) | C
-5-5 | Boombeard's Hideout (Pirate) | Tc
-5-6 | Hidden Treasure (Pirate) | S
+\#  | Track | Mode | Kart
+--- | ----- | ---- | ----
+5-1 | Beguy Market (Desert) | I | Banana Split
+5-2 | Handy Harbor (Village) | F | Lodi November
+5-3 | Downtown Dubai (World) | Em | Panda Buggy
+5-4 | Specter Pass (Tomb) | C | Lodi November
+5-5 | Boombeard's Hideout (Pirate) | Tc | Golden Lodi Kafka
+5-6 | Hidden Treasure (Pirate) | S | Monster
 
 ### Chapter 6
-\#  | Track | Mode
---- | ----- | ----
-6-1 | Panda Paradise (Wyldwood) | Tr
-6-2 | Handy Harbor (Village) | S
-6-3 | Outer Orbiter (Northeu) | C
-6-4 | Mile High Motorway (Northeu) | I
-6-5 | Rio Downhill (World) | Esc
-6-6 | Secret Basement (Castle) | Tr
+\#  | Track | Mode | Kart
+--- | ----- | ---- | ----
+6-1 | Panda Paradise (Wyldwood) | Tr | Lodi November
+6-2 | Handy Harbor (Village) | S | Lodi November
+6-3 | Outer Orbiter (Northeu) | C | Golden Roadhog
+6-4 | Mile High Motorway (Northeu) | I | Rudolf
+6-5 | Rio Downhill (World) | Esc | Monster
+6-6 | Secret Basement (Castle) | Tr | Pink Cotton
 
 ### Chapter 7
-\#  | Track | Mode
---- | ----- | ----
-7-1 | Pharoah's Pass (Desert) | S
-7-2 | Brazil Circuit (WKC) | Tt
-7-3 | Outer Orbiter (Northeu) | Em
-7-4 | Large Hot Rod Collider (Brodi) | I
-7-5 | Rio Downhill (World) | F
-7-6 | Twirling Construction Site (Desert) | Tr
+\#  | Track | Mode | Kart
+--- | ----- | ---- | ----
+7-1 | Pharoah's Pass (Desert) | S | Burst
+7-2 | Brazil Circuit (WKC) | Tt | Marathon
+7-3 | Outer Orbiter (Northeu) | Em | Marathon
+7-4 | Large Hot Rod Collider (Brodi) | I | Banana Split
+7-5 | Rio Downhill (World) | F | Saber Red
+7-6 | Twirling Construction Site (Desert) | Tr | Saber Red
 
 ### Chapter 8
-\#  | Track | Mode
---- | ----- | ----
-8-1 | Handy Harbor (Village) | Tr
-8-2 | Bridge Run (Beach) | Em
-8-3 | The Forgotten City (Mechanic) | F
-8-4 | Lumberjack Lane (Wyldwood) | C
-8-5 | Steamfunk Factory (1920) | S
-8-6 | Unfinished Zone 5 (Factory) | Tr
+\#  | Track | Mode | Kart
+--- | ----- | ---- | ----
+8-1 | Handy Harbor (Village) | Tr | Solar
+8-2 | Bridge Run (Beach) | Em | Golden Roadhog
+8-3 | The Forgotten City (Mechanic) | F | Unicorn Chariot
+8-4 | Lumberjack Lane (Wyldwood) | C | Golden Lodi Kafka
+8-5 | Steamfunk Factory (1920) | S | Unicorn Chariot
+8-6 | Unfinished Zone 5 (Factory) | Tr | Saber Red
 
 ### Chapter 9
-\#  | Track | Mode
---- | ----- | ----
-9-1 | Secrets of the Temple (Fairy) | Esc
-9-2 | Paris Grand Prix (World) | S
-9-3 | Formula 51 (Northeu) | I
-9-4 | Cubeville Heights (Block) | Em
-9-5 | Terracotta Twister (China) | C
-9-6 | Dinosaur Arena (Jurassic) | S
+\#  | Track | Mode | Kart
+--- | ----- | ---- | ----
+9-1 | Secrets of the Temple (Fairy) | Esc | Solar
+9-2 | Paris Grand Prix (World) | S | Solar
+9-3 | Formula 51 (Northeu) | I | Rudolf
+9-4 | Cubeville Heights (Block) | Em | Burst
+9-5 | Terracotta Twister (China) | C | Golden Lodi Kafka
+9-6 | Dinosaur Arena (Jurassic) | S | Pink Cotton
 
 ### Chapter 10
-\#   | Track | Mode
----- | ----- | ----
-10-1 | Steamfunk Aerodrome (1920) | F
-10-2 | Canal (Village) | R
-10-3 | Korea Circuit (WKC) | Tr
-10-4 | 360 Tower (Park) | Tr
-10-5 | Beguy Market (Desert) | Tr
-10-6 | Hidden Treasure (Pirate) | C
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+10-1 | Steamfunk Aerodrome (1920) | F | Burst
+10-2 | Canal (Village) | R | Unicorn Chariot
+10-3 | Korea Circuit (WKC) | Tr | Monster
+10-4 | 360 Tower (Park) | Tr | Saber Red
+10-5 | Beguy Market (Desert) | Tr | Golden Lodi Kafka
+10-6 | Hidden Treasure (Pirate) | C | Saber Red
 
 ### Chapter 11
-\#   | Track | Mode
----- | ----- | ----
-11-1 | Up 'N' Down (Village) | R
-11-2 | Cubeville Heights (Block) | I
-11-3 | Secret Basement (Castle) | F
-11-4 | Boombeard's Hideout (Pirate) | C
-11-5 | Rio Downhill (World) | Tr
-11-6 | Secrets of the Temple (Fairy) | Esc
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+11-1 | Up 'N' Down (Village) | R | Burst
+11-2 | Cubeville Heights (Block) | I | Turbo Tortoise
+11-3 | Secret Basement (Castle) | F | Golden Lodi Kafka
+11-4 | Boombeard's Hideout (Pirate) | C | Monster
+11-5 | Rio Downhill (World) | Tr | Golden Lodi Kafka
+11-6 | Secrets of the Temple (Fairy) | Esc | Saber Red
 
 ### Chapter 12
-\#   | Track | Mode
----- | ----- | ----
-12-1 | Shanghai Noon (China) | Tr
-12-2 | Outer Orbiter (Northeu) | Tc
-12-3 | Specter Pass (Tomb) | R
-12-4 | Corkscrew (Beach) | F
-12-5 | Steamfunk Aerodrome (1920) | Em
-12-6 | Cosmic Canyon (Northeu) | S
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+12-1 | Shanghai Noon (China) | Tr | Unicorn Chariot
+12-2 | Outer Orbiter (Northeu) | Tc | Unicorn Chariot
+12-3 | Specter Pass (Tomb) | R | Golden Lodi Kafka
+12-4 | Corkscrew (Beach) | F | Monster
+12-5 | Steamfunk Aerodrome (1920) | Em | Saber Red
+12-6 | Cosmic Canyon (Northeu) | S | Monster
 
 ### Chapter 13
-\#   | Track | Mode
----- | ----- | ----
-13-1 | The Forgotten City (Mechanic) | Tt
-13-2 | Water Aerodrome (Beach) | F
-13-3 | Twin Gates (Village) | Tr
-13-4 | Pharoah's Pass (Desert) | Tr
-13-5 | Cemetery Circuit (Tomb) | Tc
-13-6 | London Nights (World) | Esc
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+13-1 | The Forgotten City (Mechanic) | Tt | Golden Lodi Kafka
+13-2 | Water Aerodrome (Beach) | F | Golden Lodi Kafka
+13-3 | Twin Gates (Village) | Tr | Unicorn Chariot
+13-4 | Pharoah's Pass (Desert) | Tr | Saber Red
+13-5 | Cemetery Circuit (Tomb) | Tc | Monster
+13-6 | London Nights (World) | Esc | Saber Red
 
 ### Chapter 14
-\#   | Track | Mode
----- | ----- | ----
-14-1 | Kartland Park (Storybook) | Em
-14-2 | The Gate of the Wonderland (Storybook) | S
-14-3 | Steamfunk Aerodrome (1920) | R
-14-4 | Power Core (Brodi) | Tr
-14-5 | The Great Wall (Village) | S
-14-6 | Rainslick Raceway (Moonhill) | C
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+14-1 | Kartland Park (Storybook) | Em | Golden Lodi Kafka
+14-2 | The Gate of the Wonderland (Storybook) | S | Saber Red
+14-3 | Steamfunk Aerodrome (1920) | R | Pink Cotton
+14-4 | Power Core (Brodi) | Tr | Saber Red
+14-5 | The Great Wall (Village) | S | Pink Cotton
+14-6 | Rainslick Raceway (Moonhill) | C | Saber Red
 
 ### Chapter 15
-\#   | Track | Mode
----- | ----- | ----
-15-1 | Secrets of the Temple (Fairy) | Tc
-15-2 | Kartland Park (Storybook) | R
-15-3 | Formula 51 (Northeu) | I
-15-4 | Water Aerodrome (Beach) | Em
-15-5 | Canopy Curve (Wyldwood) | Tr
-15-6 | The Gate of the Wonderland (Storybook) | S
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+15-1 | Secrets of the Temple (Fairy) | Tc | Saber Red
+15-2 | Kartland Park (Storybook) | R | Golden Lodi Kafka
+15-3 | Formula 51 (Northeu) | I | Pink Cotton
+15-4 | Water Aerodrome (Beach) | Em | Saber Red
+15-5 | Canopy Curve (Wyldwood) | Tr | Monster
+15-6 | The Gate of the Wonderland (Storybook) | S | Monster
 
 ### Chapter 16
-\#   | Track | Mode
----- | ----- | ----
-16-1 | Secret Basement (Castle) | Tc
-16-2 | Canal (Village) | Tr
-16-3 | Twirling Construction Site (Desert) | Tr
-16-4 | Steamfunk Factory (1920) | Esc
-16-5 | Rainslick Raceway (Moonhill) | C
-16-6 | The Bridge of Fate (Village) | S
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+16-1 | Secret Basement (Castle) | Tc | Golden Lodi Kafka
+16-2 | Canal (Village) | Tr | Golden Lodi Kafka
+16-3 | Twirling Construction Site (Desert) | Tr | Pink Cotton
+16-4 | Steamfunk Factory (1920) | Esc | Unicorn Chariot
+16-5 | Rainslick Raceway (Moonhill) | C | Pink Cotton
+16-6 | The Bridge of Fate (Village) | S | Monster
 
 ### Chapter 17
-\#   | Track | Mode
----- | ----- | ----
-17-1 | Water Aerodrome (Beach) | S
-17-2 | Power Core (Brodi) | R
-17-3 | Cemetery Circuit (Tomb) | I
-17-4 | Namsan Tour (Village) | F
-17-5 | London Nights (World) | Tr
-17-6 | Huangshan Highway (China) | C
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+17-1 | Water Aerodrome (Beach) | S | Golden Lodi Kafka
+17-2 | Power Core (Brodi) | R | Golden Lodi Kafka
+17-3 | Cemetery Circuit (Tomb) | I | Pink Cotton
+17-4 | Namsan Tour (Village) | F | Monster
+17-5 | London Nights (World) | Tr | Unicorn Chariot
+17-6 | Huangshan Highway (China) | C | Monster
 
 ### Chapter 18
-\#   | Track | Mode
----- | ----- | ----
-18-1 | Brazil Circuit (WKC) | F
-18-2 | Dizzying Downhill (Wyldwood) | C
-18-3 | Dinosaur Arena (Jurassic) | R
-18-4 | Panda Paradise (Wyldwood) | Tr
-18-5 | Namsan Tour (Village) | Esc
-18-6 | Canopy Curve (Wyldwood) | Em
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+18-1 | Brazil Circuit (WKC) | F | Golden Lodi Kafka
+18-2 | Dizzying Downhill (Wyldwood) | C | Monster
+18-3 | Dinosaur Arena (Jurassic) | R | Golden Lodi Kafka
+18-4 | Panda Paradise (Wyldwood) | Tr | Pink Cotton
+18-5 | Namsan Tour (Village) | Esc | Monster
+18-6 | Canopy Curve (Wyldwood) | Em | Monster
 
 ### Chapter 19
-\#   | Track | Mode
----- | ----- | ----
-19-1 | Huangshan Highway (China) | R
-19-2 | Large Hot Rod Collider (Brodi) | Tr
-19-3 | The Gate of the Wonderland (Storybook) | Tc
-19-4 | Korea Circuit (WKC) | Em
-19-5 | Cemetery Circuit (Tomb) | C
-19-6 | Dino Town (Jurassic) | I
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+19-1 | Huangshan Highway (China) | R | Golden Lodi Kafka
+19-2 | Large Hot Rod Collider (Brodi) | Tr | Pink Cotton
+19-3 | The Gate of the Wonderland (Storybook) | Tc | Unicorn Chariot
+19-4 | Korea Circuit (WKC) | Em | Saber Red
+19-5 | Cemetery Circuit (Tomb) | C | Saber Red
+19-6 | Dino Town (Jurassic) | I | Saber Red
 
 ### Chapter 20
-\#   | Track | Mode
----- | ----- | ----
-20-1 | 360 Tower (Park) | F
-20-2 | Corkscrew (Beach) | R
-20-3 | The Bridge of Fate (Village) | Esc
-20-4 | Dino Town (Jurassic) | C
-20-5 | London Nights (World) | I
-20-6 | Zigzag Downhill (Mine) | S
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+20-1 | 360 Tower (Park) | F | Monster
+20-2 | Corkscrew (Beach) | R | Golden Lodi Kafka
+20-3 | The Bridge of Fate (Village) | Esc | Saber Red
+20-4 | Dino Town (Jurassic) | C | Monster
+20-5 | London Nights (World) | I | Unicorn Chariot
+20-6 | Zigzag Downhill (Mine) | S | Monster
 
 ### Chapter 21
-\#   | Track | Mode
----- | ----- | ----
-21-1 | The Great Wall (Village) | Tc
-21-2 | Boomhill Tunnel (Village) | S
-21-3 | Dangerous Volcano Jump Zone (Jurassic) | Esc
-21-4 | Tibetan Turnpike (China) | Tr
-21-5 | Cemetery Circuit (Tomb) | Esc
-21-6 | 360 Tower (Park) | F
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+21-1 | The Great Wall (Village) | Tc | Zeno
+21-2 | Boomhill Tunnel (Village) | S | Pink Cotton
+21-3 | Dangerous Volcano Jump Zone (Jurassic) | Esc | Pink Cotton
+21-4 | Tibetan Turnpike (China) | Tr | Monster
+21-5 | Cemetery Circuit (Tomb) | Esc | Saber Red
+21-6 | 360 Tower (Park) | F | Saber Red
 
 ### Chapter 22
-\#   | Track | Mode
----- | ----- | ----
-22-1 | Corkscrew (Beach) | S
-22-2 | Terracotta Twister (China) | L
-22-3 | Tibetan Turnpike (China) | Esc
-22-4 | Greek Prix (World) | I
-22-5 | Boomhill Tunnel (Village) | F
-22-6 | Brazil Circuit (WKC) | C
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+22-1 | Corkscrew (Beach) | S | Zeno
+22-2 | Terracotta Twister (China) | L | Golden Lodi Kafka
+22-3 | Tibetan Turnpike (China) | Esc | Pink Cotton
+22-4 | Greek Prix (World) | I | Unicorn Chariot
+22-5 | Boomhill Tunnel (Village) | F | Monster
+22-6 | Brazil Circuit (WKC) | C | Monster
 
 ### Chapter 23
-\#   | Track | Mode
----- | ----- | ----
-23-1 | London Nights (World) | L
-23-2 | Canopy Curve (Wyldwood) | R
-23-3 | Checkered Flag Falls (Wyldwood) | I
-23-4 | Brazil Circuit (WKC) | Em
-23-5 | Korea Circuit (WKC) | C
-23-6 | Unfinished Zone 5 (Factory) | Tc
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+23-1 | London Nights (World) | L | Zeno
+23-2 | Canopy Curve (Wyldwood) | R | Monster
+23-3 | Checkered Flag Falls (Wyldwood) | I | Banana Split
+23-4 | Brazil Circuit (WKC) | Em | Pink Cotton
+23-5 | Korea Circuit (WKC) | C | Unicorn Chariot
+23-6 | Unfinished Zone 5 (Factory) | Tc | Monster
 
 ### Chapter 24
-\#   | Track | Mode
----- | ----- | ----
-24-1 | Twirling Construction Site (Desert) | R
-24-2 | Dino Town (Jurassic) | F
-24-3 | Shipping Lanes (Beach) | Tr
-24-4 | Korea Circuit (WKC) | Tr
-24-5 | Boombeard's Hideout (Pirate) | S
-24-6 | Cosmic Canyon (Northeu) | Em
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+24-1 | Twirling Construction Site (Desert) | R | Zeno
+24-2 | Dino Town (Jurassic) | F | Monster
+24-3 | Shipping Lanes (Beach) | Tr | Pink Cotton
+24-4 | Korea Circuit (WKC) | Tr | Unicorn Chariot
+24-5 | Boombeard's Hideout (Pirate) | S | Saber Red
+24-6 | Cosmic Canyon (Northeu) | Em | Monster
 
 ### Chapter 25
-\#   | Track | Mode
----- | ----- | ----
-25-1 | Greek Prix (World) | Tr
-25-2 | Namsan Tour (Village) | C
-25-3 | Training Center (Sword) | Tc
-25-4 | Checkered Flag Falls (Wyldwood) | Tr
-25-5 | Hidden Treasure (Pirate) | F
-25-6 | Cemetery Circuit (Tomb) | I
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+25-1 | Greek Prix (World) | Tr | Dragon Blade
+25-2 | Namsan Tour (Village) | C | Pink Cotton
+25-3 | Training Center (Sword) | Tc | Dragon Blade
+25-4 | Checkered Flag Falls (Wyldwood) | Tr | Monster
+25-5 | Hidden Treasure (Pirate) | F | Saber Red
+25-6 | Cemetery Circuit (Tomb) | I | Justice
 
 ### Chapter 26
-\#   | Track | Mode
----- | ----- | ----
-26-1 | Dangerous Volcano Jump Zone (Jurassic) | Tc
-26-2 | Steamfunk Factory (1920) | F
-26-3 | Dragon's Descent (Sword) | I
-26-4 | Huangshan Highway (China) | C
-26-5 | Twin Gates (Village) | L
-26-6 | Zigzag Downhill (Mine) | Tr
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+26-1 | Dangerous Volcano Jump Zone (Jurassic) | Tc | Golden Lodi Kafka
+26-2 | Steamfunk Factory (1920) | F | Venger
+26-3 | Dragon's Descent (Sword) | I | Turbo Tortoise
+26-4 | Huangshan Highway (China) | C | Terra Blade
+26-5 | Twin Gates (Village) | L | Monster
+26-6 | Zigzag Downhill (Mine) | Tr | White Knight
 
 ### Chapter 27
-\#   | Track | Mode
----- | ----- | ----
-27-1 | Training Center (Sword) | S
-27-2 | The Bridge of Fate (Village) | Em
-27-3 | Canopy Curve (Wyldwood) | C
-27-4 | Shipping Lanes (Beach) | Esc
-27-5 | Brazil Circuit (WKC) | Tc
-27-6 | Dizzying Downhill (Wyldwood) | F
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+27-1 | Training Center (Sword) | S | Venger
+27-2 | The Bridge of Fate (Village) | Em | White Knight
+27-3 | Canopy Curve (Wyldwood) | C | Specter
+27-4 | Shipping Lanes (Beach) | Esc | Pink Cotton
+27-5 | Brazil Circuit (WKC) | Tc | Lunar Blade
+27-6 | Dizzying Downhill (Wyldwood) | F | White Knight
 
 ### Chapter 28
-\#   | Track | Mode
----- | ----- | ----
-28-1 | Dragon's Descent (Sword) | I
-28-2 | Boomhill Tunnel (Village) | C
-28-3 | The Forgotten City (Mechanic) | R
-28-4 | Tibetan Turnpike (China) | F
-28-5 | Secret Basement (Castle) | S
-28-6 | Unfinished Zone 5 (Factory) | Esc
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+28-1 | Dragon's Descent (Sword) | I | Justice
+28-2 | Boomhill Tunnel (Village) | C | Monster
+28-3 | The Forgotten City (Mechanic) | R | Pink Cotton
+28-4 | Tibetan Turnpike (China) | F | Boxster
+28-5 | Secret Basement (Castle) | S | Saber Red
+28-6 | Unfinished Zone 5 (Factory) | Esc | Monster
 
 ### Chapter 29
-\#   | Track | Mode
----- | ----- | ----
-29-1 | Frost Valley (Ice) | Tr
-29-2 | Shanghai Nights (China) | F
-29-3 | Penguin Rock (Ice) | R
-29-4 | Greek Prix (World) | C
-29-5 | Crystal Quarry (Mine) | S
-29-6 | Demon King's Invitation (Tomb) | Em
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+29-1 | Frost Valley (Ice) | Tr | Falcon
+29-2 | Shanghai Nights (China) | F | Atlas
+29-3 | Penguin Rock (Ice) | R | Sheffer
+29-4 | Greek Prix (World) | C | Monster
+29-5 | Crystal Quarry (Mine) | S | Sky Piercer
+29-6 | Demon King's Invitation (Tomb) | Em | Iceball
 
 ### Chapter 30
-\#   | Track | Mode
----- | ----- | ----
-30-1 | Dragon's Descent (Sword) | Esc
-30-2 | Lava Lane (Mine) | I
-30-3 | Iceberg Speedway (Ice) | L
-30-4 | Frost Valley (Ice) | C
-30-5 | Shark's Tomb (Ice) | Tr
-30-6 | Temple of Vroom (Gold) | C
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+30-1 | Dragon's Descent (Sword) | Esc | White Knight
+30-2 | Lava Lane (Mine) | I | Kitty Cruiser
+30-3 | Iceberg Speedway (Ice) | L | Gale
+30-4 | Frost Valley (Ice) | C | Falcon
+30-5 | Shark's Tomb (Ice) | Tr | Bluebird
+30-6 | Temple of Vroom (Gold) | C | Sky Piercer
 
 ### Chapter 31
-\#   | Track | Mode
----- | ----- | ----
-31-1 | Dangerous Volcano Jump Zone (Jurassic) | S
-31-2 | Crystal Quarry (Mine) | Em
-31-3 | Shark's Tomb (Ice) | F
-31-4 | Iceberg Speedway (Ice) | I
-31-5 | Penguin Rock (Ice) | L
-31-6 | Frost Valley (Ice) | S
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+31-1 | Dangerous Volcano Jump Zone (Jurassic) | S | Falcon
+31-2 | Crystal Quarry (Mine) | Em | Monster
+31-3 | Shark's Tomb (Ice) | F | Zeno
+31-4 | Iceberg Speedway (Ice) | I | Kitty Cruiser
+31-5 | Penguin Rock (Ice) | L | Iceball
+31-6 | Frost Valley (Ice) | S | Sky Piercer
 
 ### Chapter 32
-\#   | Track | Mode
----- | ----- | ----
-32-1 | Clock Tower (Village) | Tc
-32-2 | Temple of Vroom (Gold) | Em
-32-3 | Iceberg Speedway (Ice) | I
-32-4 | Tibetan Turnpike (China) | S
-32-5 | Shark's Tomb (Ice) | R
-32-6 | Demon King's Invitation (Tomb) | Tr
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+32-1 | Clock Tower (Village) | Tc | Iceball
+32-2 | Temple of Vroom (Gold) | Em | Iceball
+32-3 | Iceberg Speedway (Ice) | I | Justice
+32-4 | Tibetan Turnpike (China) | S | Falcon
+32-5 | Shark's Tomb (Ice) | R | Sky Piercer
+32-6 | Demon King's Invitation (Tomb) | Tr | Monster
 
 ### Chapter 33
-\#   | Track | Mode
----- | ----- | ----
-33-1 | Boomhill Tunnel (Village) | Tr
-33-2 | Crystal Quarry (Mine) | Em
-33-3 | Shipping Lanes (Beach) | L
-33-4 | Power Core (Brodi) | R
-33-5 | Temple of Vroom (Gold) | C
-33-6 | Demon King's Invitation (Tomb) | Tc
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+33-1 | Boomhill Tunnel (Village) | Tr | Falcon
+33-2 | Crystal Quarry (Mine) | Em | Atlas
+33-3 | Shipping Lanes (Beach) | L | Red Trolley
+33-4 | Power Core (Brodi) | R | Monster
+33-5 | Temple of Vroom (Gold) | C | Sky Piercer
+33-6 | Demon King's Invitation (Tomb) | Tc | Falcon
 
 ### Chapter 34
-\#   | Track | Mode
----- | ----- | ----
-34-1 | Louie's Study (Castle) | I
-34-2 | Rainslick Raceway (Moonhill) | Tr
-34-3 | Lava Lane (Mine) | R
-34-4 | The Bridge of Fate (Village) | C
-34-5 | Unfinished Zone 5 (Factory) | F
-34-6 | Frost Valley (Ice) | S
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+34-1 | Louie's Study (Castle) | I | Igloo
+34-2 | Rainslick Raceway (Moonhill) | Tr | Iceball
+34-3 | Lava Lane (Mine) | R | White Knight
+34-4 | The Bridge of Fate (Village) | C | Falcon
+34-5 | Unfinished Zone 5 (Factory) | F | Atlas
+34-6 | Frost Valley (Ice) | S | Sky Piercer
 
 ### Chapter 35
-\#   | Track | Mode
----- | ----- | ----
-35-1 | Tibetan Turnpike (China) | Tr
-35-2 | Shanghai Nights (China) | Tc
-35-3 | Up 'N' Down (Village) | C
-35-4 | Toy Factory (Block) | I
-35-5 | 360 Tower (Park) | Esc
-35-6 | Ski Resort (Ice) | S
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+35-1 | Tibetan Turnpike (China) | Tr | Falcon
+35-2 | Shanghai Nights (China) | Tc | Monster
+35-3 | Up 'N' Down (Village) | C | Saber Red
+35-4 | Toy Factory (Block) | I | Kitty Cruiser
+35-5 | 360 Tower (Park) | Esc | Pink Cotton
+35-6 | Ski Resort (Ice) | S | Sky Piercer
 
 ### Chapter 36
-\#   | Track | Mode
----- | ----- | ----
-36-1 | Toy Factory (Block) | L
-36-2 | Crystal Quarry (Mine) | Esc
-36-3 | Louie's Study (Castle) | S
-36-4 | Unfinished Zone 5 (Factory) | Tr
-36-5 | Power Core (Brodi) | Em
-36-6 | Large Hot Rod Collider (Brodi) | I
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+36-1 | Toy Factory (Block) | L | Couples Carriage
+36-2 | Crystal Quarry (Mine) | Esc | White Knight
+36-3 | Louie's Study (Castle) | S | Gale
+36-4 | Unfinished Zone 5 (Factory) | Tr | Falcon
+36-5 | Power Core (Brodi) | Em | Sky Piercer
+36-6 | Large Hot Rod Collider (Brodi) | I | Justice
 
 ### Chapter 37
-\#   | Track | Mode
----- | ----- | ----
-37-1 | Up 'N' Down (Village) | S
-37-2 | Dragon's Canal (China) | Em
-37-3 | Shanghai Noon (China) | L
-37-4 | Dragon Palace (China) | Tr
-37-5 | Louie's Study (Castle) | Esc
-37-6 | The Great Wall (Village) | F
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+37-1 | Up 'N' Down (Village) | S | Cyclone Solid
+37-2 | Dragon's Canal (China) | Em | Cyclone Solid
+37-3 | Shanghai Noon (China) | L | Nimbus
+37-4 | Dragon Palace (China) | Tr | White Knight
+37-5 | Louie's Study (Castle) | Esc | Golden Drake
+37-6 | The Great Wall (Village) | F | Chaos
 
 ### Chapter 38
-\#   | Track | Mode
----- | ----- | ----
-38-1 | Lumberjack Lane (Wyldwood) | Esc
-38-2 | Checkered Flag Falls (Wyldwood) | I
-38-3 | Twirling Construction Site (Desert) | S
-38-4 | Tibetan Turnpike (China) | L
-38-5 | Dizzying Downhill (Wyldwood) | R
-38-6 | Huangshan Highway (China) | C
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+38-1 | Lumberjack Lane (Wyldwood) | Esc | Ice Cotton
+38-2 | Checkered Flag Falls (Wyldwood) | I | Nimbus
+38-3 | Twirling Construction Site (Desert) | S | Monster
+38-4 | Tibetan Turnpike (China) | L | Festive Lollipop
+38-5 | Dizzying Downhill (Wyldwood) | R | Emperor's New Car
+38-6 | Huangshan Highway (China) | C | Chaos
 
 ### Chapter 39
-\#   | Track | Mode
----- | ----- | ----
-39-1 | Greek Prix (World) | Tr
-39-2 | Secrets of the Temple (Fairy) | F
-39-3 | Canopy Curve (Wyldwood) | C
-39-4 | Training Center (Sword) | L
-39-5 | The Gate of the Wonderland (Storybook) | Tc
-39-6 | Huangshan Highway (China) | Esc
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+39-1 | Greek Prix (World) | Tr | Moonshade
+39-2 | Secrets of the Temple (Fairy) | F | Emperor's New Car
+39-3 | Canopy Curve (Wyldwood) | C | Ice Cotton
+39-4 | Training Center (Sword) | L | Moonshade
+39-5 | The Gate of the Wonderland (Storybook) | Tc | Atlas
+39-6 | Huangshan Highway (China) | Esc | Chaos
 
 ### Chapter 40
-\#   | Track | Mode
----- | ----- | ----
-40-1 | Dragon's Descent (Sword) | Tc
-40-2 | Terracotta Twister (China) | Tr
-40-3 | Temple of Vroom (Gold) | Tr
-40-4 | Dragon's Canal (China) | Tr
-40-5 | Terracotta Twister (China) | I
-40-6 | Dragon Palace (China) | Em
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+40-1 | Dragon's Descent (Sword) | Tc | Moonshade
+40-2 | Terracotta Twister (China) | Tr | Ice Cotton
+40-3 | Temple of Vroom (Gold) | Tr | Golden Drake
+40-4 | Dragon's Canal (China) | Tr | Nimbus
+40-5 | Terracotta Twister (China) | I | Festive Lollipop
+40-6 | Dragon Palace (China) | Em | Chaos
 
 ### Chapter 41
-\#   | Track | Mode
----- | ----- | ----
-41-1 | Formula 51 (Northeu) | Tr
-41-2 | Namsan Tour (Village) | C
-41-3 | Outer Orbiter (Northeu) | S
-41-4 | Louie's Study (Castle) | Esc
-41-5 | Mile High Motorway (Northeu) | F
-41-6 | Cosmic Canyon (Northeu) | S
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+41-1 | Formula 51 (Northeu) | Tr | Rolling Saucer
+41-2 | Namsan Tour (Village) | C | Banshee
+41-3 | Outer Orbiter (Northeu) | S | Emperor's New Car
+41-4 | Louie's Study (Castle) | Esc | Dark Starfall
+41-5 | Mile High Motorway (Northeu) | F | Mechanix
+41-6 | Cosmic Canyon (Northeu) | S | White Knight
 
 ### Chapter 42
-\#   | Track | Mode
----- | ----- | ----
-42-1 | Formula 51 (Northeu) | Esc
-42-2 | The Forgotten City (Mechanic) | C
-42-3 | Power Core (Brodi) | Tc
-42-4 | Large Hot Rod Collider (Brodi) | C
-42-5 | Mysterious Lab (Brodi) | Tr
-42-6 | Jump Point (Northeu) | I
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+42-1 | Formula 51 (Northeu) | Esc | Emperor's New Car
+42-2 | The Forgotten City (Mechanic) | C | Mechanix
+42-3 | Power Core (Brodi) | Tc | Rolling Saucer
+42-4 | Large Hot Rod Collider (Brodi) | C | Banshee
+42-5 | Mysterious Lab (Brodi) | Tr | Rolling Saucer
+42-6 | Jump Point (Northeu) | I | Phoenix
 
 ### Chapter 43
-\#   | Track | Mode
----- | ----- | ----
-43-1 | Path to Oret (Gold) | Tr
-43-2 | Water Aerodrome (Beach) | R
-43-3 | Mysterious Lab (Brodi) | F
-43-4 | Jump Point (Northeu) | Em
-43-5 | Mile High Motorway (Northeu) | I
-43-6 | [R] Jump Point (Northeu) | Esc
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+43-1 | Path to Oret (Gold) | Tr | Chaos
+43-2 | Water Aerodrome (Beach) | R | Banshee
+43-3 | Mysterious Lab (Brodi) | F | Monster
+43-4 | Jump Point (Northeu) | Em | Cherub Cruiser
+43-5 | Mile High Motorway (Northeu) | I | Rolling Saucer
+43-6 | [R] Jump Point (Northeu) | Esc | Dark Starfall
 
 ### Chapter 44
-\#   | Track | Mode
----- | ----- | ----
-44-1 | Large Hot Rod Collider (Brodi) | R
-44-2 | Unfinished Zone 5 (Factory) | F
-44-3 | Up 'N' Down (Village) | Tr
-44-4 | Path to Oret (Gold) | S
-44-5 | [R] Jump Point (Northeu) | Tr
-44-6 | Cosmic Canyon (Northeu) | S
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+44-1 | Large Hot Rod Collider (Brodi) | R | Emperor's New Car
+44-2 | Unfinished Zone 5 (Factory) | F | Mechanix
+44-3 | Up 'N' Down (Village) | Tr | Cherub Cruiser
+44-4 | Path to Oret (Gold) | S | Dark Starfall
+44-5 | [R] Jump Point (Northeu) | Tr | Banshee
+44-6 | Cosmic Canyon (Northeu) | S | Dark Starfall
 
 ### Chapter 45
-\#   | Track | Mode
----- | ----- | ----
-45-1 | 360 Tower (Park) | S
-45-2 | Clock Tower (Village) | Tr
-45-3 | Kartland Park (Storybook) | F
-45-4 | Beanstalk Raceway (Storybook) | R
-45-5 | Path to Oret (Gold) | Tc
-45-6 | Card Kingdom Maze (Storybook) | Em
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+45-1 | 360 Tower (Park) | S | Pink Scooter
+45-2 | Clock Tower (Village) | Tr | Night Eagle
+45-3 | Kartland Park (Storybook) | F | Sweeper
+45-4 | Beanstalk Raceway (Storybook) | R | Cyber Burst
+45-5 | Path to Oret (Gold) | Tc | Dark Starfall
+45-6 | Card Kingdom Maze (Storybook) | Em | Galaxy Salvation
 
 ### Chapter 46
-\#   | Track | Mode
----- | ----- | ----
-46-1 | Greek Prix (World) | I
-46-2 | [R] Up 'N' Down (Village) | Esc
-46-3 | Extreme Zone (Village) | Tr
-46-4 | Ice Lantern Road (China) | Tr
-46-5 | Lumberjack Lane (Wyldwood) | I
-46-6 | The Gate of the Wonderland (Storybook) | S
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+46-1 | Greek Prix (World) | I | Octokart
+46-2 | [R] Up 'N' Down (Village) | Esc | Pink Scooter
+46-3 | Extreme Zone (Village) | Tr | Seth
+46-4 | Ice Lantern Road (China) | Tr | Dark Knight
+46-5 | Lumberjack Lane (Wyldwood) | I | Octokart
+46-6 | The Gate of the Wonderland (Storybook) | S | Night Eagle
 
 ### Chapter 47
-\#   | Track | Mode
----- | ----- | ----
-47-1 | Card Kingdom Maze (Storybook) | F
-47-2 | Beanstalk Raceway (Storybook) | Tr
-47-3 | Kartland Park (Storybook) | L
-47-4 | Louie's Study (Castle) | I
-47-5 | Checkered Flag Falls (Wyldwood) | Em
-47-6 | Card Kingdom Maze (Storybook) | I
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+47-1 | Card Kingdom Maze (Storybook) | F | Sweeper
+47-2 | Beanstalk Raceway (Storybook) | Tr | Mechanix
+47-3 | Kartland Park (Storybook) | L | Pink Scooter
+47-4 | Louie's Study (Castle) | I | Seth
+47-5 | Checkered Flag Falls (Wyldwood) | Em | Dark Knight
+47-6 | Card Kingdom Maze (Storybook) | I | Sweeper
 
 ### Chapter 48
-\#   | Track | Mode
----- | ----- | ----
-48-1 | 360 Tower (Park) | R
-48-2 | Extreme Zone (Village) | Em
-48-3 | Louie's Dollhouse (Castle) | Tc
-48-4 | Kartland Park (Storybook) | I
-48-5 | [R] Up 'N' Down (Village) | B
-48-6 | Alleyway Sprint (China) | S
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+48-1 | 360 Tower (Park) | R | Sweeper
+48-2 | Extreme Zone (Village) | Em | Cyber Burst
+48-3 | Louie's Dollhouse (Castle) | Tc | Mechanix
+48-4 | Kartland Park (Storybook) | I | Sweeper
+48-5 | [R] Up 'N' Down (Village) | B | Dark Starfall
+48-6 | Alleyway Sprint (China) | S | Night Eagle
 
 ### Chapter 49
-\#   | Track | Mode
----- | ----- | ----
-49-1 | Twin Gates (Village) | Tr
-49-2 | New York Rally (World) | F
-49-3 | Shipping Lanes (Beach) | Em
-49-4 | Greek Prix (World) | L
-49-5 | Steamfunk Aerodrome (1920) | S
-49-6 | Paris Grand Prix (World) | Tr
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+49-1 | Twin Gates (Village) | Tr | Screamin' Skateboard
+49-2 | New York Rally (World) | F | Octokart
+49-3 | Shipping Lanes (Beach) | Em | Shadow Sheffer
+49-4 | Greek Prix (World) | L | Screamin' Skateboard
+49-5 | Steamfunk Aerodrome (1920) | S | Night Eagle
+49-6 | Paris Grand Prix (World) | Tr | Dark Knight
 
 ### Chapter 50
-\#   | Track | Mode
----- | ----- | ----
-50-1 | Paris Eiffel Tower Dive (World) | F
-50-2 | Water Aerodrome (Beach) | I
-50-3 | Ancient Ruins (Desert) | C
-50-4 | London Nights (World) | R
-50-5 | Namsan Tour (Village) | B
-50-6 | Extreme Zone (Village) | Tr
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+50-1 | Paris Eiffel Tower Dive (World) | F | Stingray
+50-2 | Water Aerodrome (Beach) | I | Mini School Bus
+50-3 | Ancient Ruins (Desert) | C | Brutus
+50-4 | London Nights (World) | R | Stingray
+50-5 | Namsan Tour (Village) | B | Screamin' Skateboard
+50-6 | Extreme Zone (Village) | Tr | Shadow Sheffer
 
 ### Chapter 51
-\#   | Track | Mode
----- | ----- | ----
-51-1 | Paris Eiffel Tower Dive (World) | Tt
-51-2 | Clock Tower (Village) | R
-51-3 | [R] Up 'N' Down (Village) | L
-51-4 | The Bridge of Fate (Village) | Em
-51-5 | Extreme Zone (Village) | C
-51-6 | [R] Cemetery Circuit (Tomb) | I
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+51-1 | Paris Eiffel Tower Dive (World) | Tt | Octokart
+51-2 | Clock Tower (Village) | R | Brutus
+51-3 | [R] Up 'N' Down (Village) | L | Sweeper
+51-4 | The Bridge of Fate (Village) | Em | Night Eagle
+51-5 | Extreme Zone (Village) | C | Saber Hellfire
+51-6 | [R] Cemetery Circuit (Tomb) | I | Fearless Dao
 
 ### Chapter 52
-\#   | Track | Mode
----- | ----- | ----
-52-1 | Lava Lane (Mine) | Tc
-52-2 | Rio Downhill (World) | Em
-52-3 | Pharoah's Pass (Desert) | Tr
-52-4 | Ancient Ruins (Desert) | I
-52-5 | Downtown Dubai (World) | Em
-52-6 | New York Rally (World) | S
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+52-1 | Lava Lane (Mine) | Tc | Sweeper
+52-2 | Rio Downhill (World) | Em | Shadow Sheffer
+52-3 | Pharoah's Pass (Desert) | Tr | Dark Knight
+52-4 | Ancient Ruins (Desert) | I | Grand Piano
+52-5 | Downtown Dubai (World) | Em | Mini School Bus
+52-6 | New York Rally (World) | S | Saber Hellfire
 
 ### Chapter 53
-\#   | Track | Mode
----- | ----- | ----
-53-1 | Checkered Flag Falls (Wyldwood) | Tr
-53-2 | Path to Oret (Gold) | S
-53-3 | Boulder Dash (Gold) | C
-53-4 | Temple of Vroom (Gold) | Tr
-53-5 | Falcon's Reach (Gold) | R
-53-6 | Dragon's Lake (China) | S
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+53-1 | Checkered Flag Falls (Wyldwood) | Tr | Marathon Redux
+53-2 | Path to Oret (Gold) | S | Lantern Fisher
+53-3 | Boulder Dash (Gold) | C | Regalia
+53-4 | Temple of Vroom (Gold) | Tr | Rosy Mobster
+53-5 | Falcon's Reach (Gold) | R | Shadow Meteor
+53-6 | Dragon's Lake (China) | S | Atlas Redux
 
 ### Chapter 54
-\#   | Track | Mode
----- | ----- | ----
-54-1 | Lava Lane (Mine) | F
-54-2 | Falcon's Reach (Gold) | Em
-54-3 | Temple of Vroom (Gold) | C
-54-4 | Dangerous Volcano Jump Zone (Jurassic) | Tr
-54-5 | Crystal Quarry (Mine) | I
-54-6 | Zigzag Downhill (Mine) | Tr
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+54-1 | Lava Lane (Mine) | F | Taxicab
+54-2 | Falcon's Reach (Gold) | Em | Froyo Flier
+54-3 | Temple of Vroom (Gold) | C | Lantern Fisher
+54-4 | Dangerous Volcano Jump Zone (Jurassic) | Tr | Regalia
+54-5 | Crystal Quarry (Mine) | I | Trailmaster
+54-6 | Zigzag Downhill (Mine) | Tr | Atlas Redux
 
 ### Chapter 55
-\#   | Track | Mode
----- | ----- | ----
-55-1 | Tower of Pisa (World) | S
-55-2 | Ancient Ruins (Desert) | I
-55-3 | Twirling Construction Site (Desert) | C
-55-4 | Rio Downhill (World) | Em
-55-5 | Path to Oret (Gold) | Tc
-55-6 | Dino Boneyard (Jurassic) | S
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+55-1 | Tower of Pisa (World) | S | Shadow Meteor
+55-2 | Ancient Ruins (Desert) | I | Lantern Fisher
+55-3 | Twirling Construction Site (Desert) | C | Rosy Mobster
+55-4 | Rio Downhill (World) | Em | Marathon Redux
+55-5 | Path to Oret (Gold) | Tc | Trailmaster
+55-6 | Dino Boneyard (Jurassic) | S | Ranger
 
 ### Chapter 56
-\#   | Track | Mode
----- | ----- | ----
-56-1 | Boulder Dash (Gold) | Esc
-56-2 | Temple of Vroom (Gold) | Em
-56-3 | Lava Lane (Mine) | Tc
-56-4 | Crystal Quarry (Mine) | F
-56-5 | Falcon's Reach (Gold) | I
-56-6 | Dizzying Downhill (Wyldwood) | S
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+56-1 | Boulder Dash (Gold) | Esc | Shadow Meteor
+56-2 | Temple of Vroom (Gold) | Em | Froyo Flier
+56-3 | Lava Lane (Mine) | Tc | Taxicab
+56-4 | Crystal Quarry (Mine) | F | Trailmaster
+56-5 | Falcon's Reach (Gold) | I | Froyo Flier
+56-6 | Dizzying Downhill (Wyldwood) | S | Ranger
 
 ### Chapter 57
-\#   | Track | Mode
----- | ----- | ----
-57-1 | Checkered Flag Falls (Wyldwood) | S
-57-2 | Tenderfoot Trail (Wyldwood) | S
-57-3 | Beanstalk Raceway (Storybook) | Esc
-57-4 | Clock Tower (Village) | S
-57-5 | Lumberjack Lane (Wyldwood) | R
-57-6 | The Gate of the Wonderland (Storybook) | S
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+57-1 | Checkered Flag Falls (Wyldwood) | S | Magic Carpet
+57-2 | Tenderfoot Trail (Wyldwood) | S | Guardian
+57-3 | Beanstalk Raceway (Storybook) | Esc | Wildcat
+57-4 | Clock Tower (Village) | S | Supercycle
+57-5 | Lumberjack Lane (Wyldwood) | R | Rooster Booster
+57-6 | The Gate of the Wonderland (Storybook) | S | Purrowler
 
 ### Chapter 58
-\#   | Track | Mode
----- | ----- | ----
-58-1 | Canopy Curve (Wyldwood) | Esc
-58-2 | Demon King's Invitation (Tomb) | F
-58-3 | Crystal Quarry (Mine) | I
-58-4 | Lava Lane (Mine) | C
-58-5 | Knobbly Log Lane (Fairy) | Tr
-58-6 | Zigzag Downhill (Mine) | S
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+58-1 | Canopy Curve (Wyldwood) | Esc | Mantis
+58-2 | Demon King's Invitation (Tomb) | F | Magic Carpet
+58-3 | Crystal Quarry (Mine) | I | Rooster Booster
+58-4 | Lava Lane (Mine) | C | Guardian
+58-5 | Knobbly Log Lane (Fairy) | Tr | Wildcat
+58-6 | Zigzag Downhill (Mine) | S | Supercycle
 
 ### Chapter 59
-\#   | Track | Mode
----- | ----- | ----
-59-1 | Boombeard's Hideout (Pirate) | S
-59-2 | Pirate's Cay (Pirate) | Tc
-59-3 | Secrets of the Temple (Fairy) | Em
-59-4 | Fairy Snail Pass (Fairy) | I
-59-5 | Pirate's Cay (Pirate) | C
-59-6 | Cubeville Heights (Block) | I
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+59-1 | Boombeard's Hideout (Pirate) | S | Mantis
+59-2 | Pirate's Cay (Pirate) | Tc | Purrowler
+59-3 | Secrets of the Temple (Fairy) | Em | Magic Carpet
+59-4 | Fairy Snail Pass (Fairy) | I | Guardian
+59-5 | Pirate's Cay (Pirate) | C | Wildcat
+59-6 | Cubeville Heights (Block) | I | Royal Chariot
 
 ### Chapter 60
-\#   | Track | Mode
----- | ----- | ----
-60-1 | Secrets of the Temple (Fairy) | F
-60-2 | Knobbly Log Lane (Fairy) | S
-60-3 | Fairy Snail Pass (Fairy) | I
-60-4 | Tenderfoot Trail (Wyldwood) | S
-60-5 | Checkered Flag Falls (Wyldwood) | I
-60-6 | [R] Canopy Curve (Wyldwood) | S
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+60-1 | Secrets of the Temple (Fairy) | F | Mantis
+60-2 | Knobbly Log Lane (Fairy) | S | Purrowler
+60-3 | Fairy Snail Pass (Fairy) | I | Wildcat
+60-4 | Tenderfoot Trail (Wyldwood) | S | Supercycle
+60-5 | Checkered Flag Falls (Wyldwood) | I | Royal Chariot
+60-6 | [R] Canopy Curve (Wyldwood) | S | Mantis
 
 ### Chapter 61
-\#   | Track | Mode
----- | ----- | ----
-61-1 | Gods' Realm (Norse) | Tr
-61-2 | Luminous Bridge (Norse) | C
-61-3 | Up 'N' Down (Village) | R
-61-4 | Rainslick Raceway (Moonhill) | F
-61-5 | Downtown Dubai (World) | Tr
-61-6 | Shipping Lanes (Beach) | I
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+61-1 | Gods' Realm (Norse) | Tr | Soundwave Speeder
+61-2 | Luminous Bridge (Norse) | C | Mantis
+61-3 | Up 'N' Down (Village) | R | Charger
+61-4 | Rainslick Raceway (Moonhill) | F | Monowheeler
+61-5 | Downtown Dubai (World) | Tr | Golden Boxster
+61-6 | Shipping Lanes (Beach) | I | Shadow Dragster
 
 ### Chapter 62
-\#   | Track | Mode
----- | ----- | ----
-62-1 | Cloud Valley (Sword) | S
-62-2 | Luminous Bridge (Norse) | Tr
-62-3 | Gods' Realm (Norse) | C
-62-4 | Handy Harbor (Village) | I
-62-5 | Clock Tower (Village) | L
-62-6 | Cloud Valley (Sword) | Esc
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+62-1 | Cloud Valley (Sword) | S | Shadow Flier
+62-2 | Luminous Bridge (Norse) | Tr | Guardian
+62-3 | Gods' Realm (Norse) | C | Shadow Flier
+62-4 | Handy Harbor (Village) | I | Shadow Dragster
+62-5 | Clock Tower (Village) | L | Mithril Leaf
+62-6 | Cloud Valley (Sword) | Esc | Mantis
 
 ### Chapter 63
-\#   | Track | Mode
----- | ----- | ----
-63-1 | Bridge Run (Beach) | S
-63-2 | Line of Fire (Mechanic) | Em
-63-3 | Water Aerodrome (Beach) | Tr
-63-4 | Tibetan Turnpike (China) | R
-63-5 | Greek Prix (World) | I
-63-6 | Gods' Realm (Norse) | Tc
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+63-1 | Bridge Run (Beach) | S | Monowheeler
+63-2 | Line of Fire (Mechanic) | Em | Soundwave Speeder
+63-3 | Water Aerodrome (Beach) | Tr | Charger
+63-4 | Tibetan Turnpike (China) | R | Shadow Dragster
+63-5 | Greek Prix (World) | I | Guardian
+63-6 | Gods' Realm (Norse) | Tc | Charger
 
 ### Chapter 64
-\#   | Track | Mode
----- | ----- | ----
-64-1 | Cloud Valley (Sword) | S
-64-2 | The Bridge of Fate (Village) | C
-64-3 | Clock Tower (Village) | I
-64-4 | The Great Wall (Village) | C
-64-5 | Steamfunk Aerodrome (1920) | F
-64-6 | Luminous Bridge (Norse) | S
+\#   | Track | Mode | Kart
+---- | ----- | ---- | ----
+64-1 | Cloud Valley (Sword) | S | Golden Boxster
+64-2 | The Bridge of Fate (Village) | C | Charger
+64-3 | Clock Tower (Village) | I | Shadow Dragster
+64-4 | The Great Wall (Village) | C | Monowheeler
+64-5 | Steamfunk Aerodrome (1920) | F | Shadow Flier
+64-6 | Luminous Bridge (Norse) | S | Mantis
 
 
 ## Future Factory

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@
 ---- | ----- | ---- | ----
 37-1 | Up 'N' Down (Village) | S | Cyclone Solid
 37-2 | Dragon's Canal (China) | Em | Cyclone Solid
-37-3 | Shanghai Noon (China) | L | Nimbus
+37-3 | Shanghai Noon (China) | L | Somersault Cloud
 37-4 | Dragon Palace (China) | Tr | White Knight
 37-5 | Louie's Study (Castle) | Esc | Golden Drake
 37-6 | The Great Wall (Village) | F | Chaos
@@ -401,7 +401,7 @@
 \#   | Track | Mode | Kart
 ---- | ----- | ---- | ----
 38-1 | Lumberjack Lane (Wyldwood) | Esc | Ice Cotton
-38-2 | Checkered Flag Falls (Wyldwood) | I | Nimbus
+38-2 | Checkered Flag Falls (Wyldwood) | I | Somersault Cloud
 38-3 | Twirling Construction Site (Desert) | S | Monster
 38-4 | Tibetan Turnpike (China) | L | Festive Lollipop
 38-5 | Dizzying Downhill (Wyldwood) | R | Emperor's New Car
@@ -423,7 +423,7 @@
 40-1 | Dragon's Descent (Sword) | Tc | Moonshade
 40-2 | Terracotta Twister (China) | Tr | Ice Cotton
 40-3 | Temple of Vroom (Gold) | Tr | Golden Drake
-40-4 | Dragon's Canal (China) | Tr | Nimbus
+40-4 | Dragon's Canal (China) | Tr | Somersault Cloud
 40-5 | Terracotta Twister (China) | I | Festive Lollipop
 40-6 | Dragon Palace (China) | Em | Chaos
 

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@
 ---- | ----- | ---- | ----
 37-1 | Up 'N' Down (Village) | S | Cyclone Solid
 37-2 | Dragon's Canal (China) | Em | Cyclone Solid
-37-3 | Shanghai Noon (China) | L | Somersault Cloud
+37-3 | Shanghai Noon (China) | L | Nimbus
 37-4 | Dragon Palace (China) | Tr | White Knight
 37-5 | Louie's Study (Castle) | Esc | Golden Drake
 37-6 | The Great Wall (Village) | F | Chaos
@@ -401,7 +401,7 @@
 \#   | Track | Mode | Kart
 ---- | ----- | ---- | ----
 38-1 | Lumberjack Lane (Wyldwood) | Esc | Ice Cotton
-38-2 | Checkered Flag Falls (Wyldwood) | I | Somersault Cloud
+38-2 | Checkered Flag Falls (Wyldwood) | I | Nimbus
 38-3 | Twirling Construction Site (Desert) | S | Monster
 38-4 | Tibetan Turnpike (China) | L | Festive Lollipop
 38-5 | Dizzying Downhill (Wyldwood) | R | Emperor's New Car
@@ -423,7 +423,7 @@
 40-1 | Dragon's Descent (Sword) | Tc | Moonshade
 40-2 | Terracotta Twister (China) | Tr | Ice Cotton
 40-3 | Temple of Vroom (Gold) | Tr | Golden Drake
-40-4 | Dragon's Canal (China) | Tr | Somersault Cloud
+40-4 | Dragon's Canal (China) | Tr | Nimbus
 40-5 | Terracotta Twister (China) | I | Festive Lollipop
 40-6 | Dragon Palace (China) | Em | Chaos
 


### PR DESCRIPTION
resolve #7
Karts now all filled in.

One concern:
When the Nimbus kart was added in Season 4 it was called Somersault Cloud. Not sure when it was changed to Nimbus, possibly only a few weeks ago. The website used for the checks still calls it Somersault Cloud, so that is what I named the kart to satisfy the checks, despite it now being wrong.